### PR TITLE
Solve sphinxcontrib.email: AttributeError in python3

### DIFF
--- a/email/sphinxcontrib/email.py
+++ b/email/sphinxcontrib/email.py
@@ -10,9 +10,14 @@ from docutils import nodes
 # a BSD license.
 
 import re
-import string
 
-rot_13_trans = string.maketrans(
+try:
+    maketrans = ''.maketrans
+except AttributeError:
+    # fallback for Python 2
+    from string import maketrans
+
+rot_13_trans = maketrans(
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
     'NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm'
 )
@@ -57,7 +62,6 @@ def email_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     """
     Role to obfuscate e-mail addresses.
     """
-    print 123456789, text, '\n\n'
     text = text.decode('utf-8').encode('utf-8')
     # Handle addresses of the form "Name <name@domain.org>"
     if '<' in text and '>' in text:
@@ -76,4 +80,3 @@ def email_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
 
 def setup(app):
     app.add_role('email', email_role)
-


### PR DESCRIPTION
The following changes make sphinxcontrib.email functional in python3 and solve the following issue: [sphinxcontrib.email: AttributeError (module 'string' has no attribute 'maketrans'](https://github.com/thewtex/sphinx-contrib/issues/9)

The changes were tested on an Ubuntu 18.04.1 machine with Sphinx (sphinx-build) 1.6.7 and Python 3.6.7
